### PR TITLE
Set h5 text color to white

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6,6 +6,11 @@
     --dark: #0e1016;
 }
 
+/* Heading styles */
+h5 {
+    color: #ffffff;
+}
+
 /* Set global background color */
 body {
     background-color: #14171f;


### PR DESCRIPTION
## Summary
- globally set `h5` headings to white text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6867e9961f8c83298d84c27d4b2a0098