### PR TITLE
Make headings white

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -7,7 +7,7 @@
 }
 
 /* Heading styles */
-h5 {
+h1, h2, h3, h4, h5, h6 {
     color: #ffffff;
 }
 

--- a/scss/bootstrap.scss
+++ b/scss/bootstrap.scss
@@ -9,7 +9,7 @@ $font-family-base: 'Open Sans', sans-serif;
 
 $body-color: $secondary;
 
-$headings-color: $dark;
+$headings-color: $white;
 
 $headings-font-weight: 600;
 


### PR DESCRIPTION
## Summary
- use white font color for all headings in style.css
- set `$headings-color` to white in the Bootstrap SCSS to keep styles consistent

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6867ee40b73c8329a93945341fcb8e38