### PR TITLE
Add neon glow effect to game cards

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -501,8 +501,8 @@ body {
 
 .game-card:hover {
     margin-top: -10px;
-    box-shadow: none;
-    border-color: #DEE2E6;
+    border-color: var(--primary);
+    box-shadow: 0 0 10px var(--primary), 0 0 20px var(--primary), 0 0 30px var(--primary);
 }
 
 .game-card .game-img {


### PR DESCRIPTION
## Summary
- enhance `.game-card:hover` with a neon-like outer shadow in the primary color

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686ba3ff5474832986d08ccff89c1023