### PR TITLE
Add orange hover to service cards

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -274,8 +274,8 @@ body {
 
 .service-item:hover {
     margin-top: -10px;
-    box-shadow: none;
-    border: 1px solid #DEE2E6;
+    border-color: var(--primary);
+    box-shadow: 0 0 10px var(--primary), 0 0 20px var(--primary), 0 0 30px var(--primary);
 }
 
 


### PR DESCRIPTION
## Summary
- update `service-item` hover to use primary color border and glow

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_686bc2d5b610832983d960c9e76b7e8a