### PR TITLE
Add casino themed bonus images

### DIFF
--- a/img/bonus1.svg
+++ b/img/bonus1.svg
@@ -1,4 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
   <rect width="200" height="200" fill="#ff6666" />
-  <text x="100" y="105" font-size="36" font-family="Arial" text-anchor="middle" fill="#ffffff">Bonus 1</text>
+  <rect x="50" y="40" width="100" height="120" rx="10" fill="#ffffff" />
+  <text x="100" y="110" font-size="40" font-family="Arial" text-anchor="middle" fill="#ff6666">777</text>
+  <line x1="150" y1="60" x2="170" y2="40" stroke="#ffffff" stroke-width="6" />
+  <circle cx="175" cy="35" r="8" fill="#ffffff" />
 </svg>

--- a/img/bonus2.svg
+++ b/img/bonus2.svg
@@ -1,4 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
   <rect width="200" height="200" fill="#66cc66" />
-  <text x="100" y="105" font-size="36" font-family="Arial" text-anchor="middle" fill="#ffffff">Bonus 2</text>
+  <rect x="40" y="50" width="60" height="60" rx="10" fill="#ffffff" />
+  <circle cx="70" cy="80" r="5" fill="#000000" />
+  <rect x="100" y="90" width="60" height="60" rx="10" fill="#ffffff" />
+  <circle cx="130" cy="120" r="5" fill="#000000" />
+  <circle cx="115" cy="105" r="5" fill="#000000" />
+  <circle cx="145" cy="135" r="5" fill="#000000" />
 </svg>

--- a/img/bonus3.svg
+++ b/img/bonus3.svg
@@ -1,4 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
   <rect width="200" height="200" fill="#6666ff" />
-  <text x="100" y="105" font-size="36" font-family="Arial" text-anchor="middle" fill="#ffffff">Bonus 3</text>
+  <circle cx="100" cy="100" r="70" fill="#ffffff" />
+  <circle cx="100" cy="100" r="50" fill="#ff0000" />
+  <circle cx="100" cy="100" r="20" fill="#ffffff" />
+  <line x1="100" y1="30" x2="100" y2="170" stroke="#000000" stroke-width="4" />
+  <line x1="30" y1="100" x2="170" y2="100" stroke="#000000" stroke-width="4" />
 </svg>

--- a/img/bonus4.svg
+++ b/img/bonus4.svg
@@ -1,4 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
   <rect width="200" height="200" fill="#ffcc66" />
-  <text x="100" y="105" font-size="36" font-family="Arial" text-anchor="middle" fill="#333333">Bonus 4</text>
+  <rect x="60" y="50" width="80" height="110" rx="8" fill="#ffffff" stroke="#000000" stroke-width="3" />
+  <rect x="80" y="40" width="80" height="110" rx="8" fill="#ffffff" stroke="#000000" stroke-width="3" />
+  <text x="100" y="115" font-size="40" font-family="Arial" text-anchor="middle" fill="#ff0000">A</text>
+  <text x="120" y="105" font-size="20" font-family="Arial" text-anchor="middle" fill="#000000">♠</text>
 </svg>

--- a/img/bonus5.svg
+++ b/img/bonus5.svg
@@ -1,4 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
   <rect width="200" height="200" fill="#ff6666" />
-  <text x="100" y="105" font-size="36" font-family="Arial" text-anchor="middle" fill="#ffffff">Bonus 1</text>
+  <ellipse cx="100" cy="100" rx="60" ry="20" fill="#ffffff" />
+  <ellipse cx="100" cy="90" rx="60" ry="20" fill="#ff0000" />
+  <ellipse cx="100" cy="80" rx="60" ry="20" fill="#ffffff" />
+  <ellipse cx="100" cy="70" rx="60" ry="20" fill="#ff0000" />
+  <ellipse cx="100" cy="60" rx="60" ry="20" fill="#ffffff" />
 </svg>

--- a/img/bonus6.svg
+++ b/img/bonus6.svg
@@ -1,4 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
   <rect width="200" height="200" fill="#66cc66" />
-  <text x="100" y="105" font-size="36" font-family="Arial" text-anchor="middle" fill="#ffffff">Bonus 2</text>
+  <path d="M70 70 L130 70 L150 130 Q100 160 50 130 Z" fill="#ffcc00" stroke="#000" stroke-width="3" />
+  <circle cx="100" cy="90" r="15" fill="#ffffff" />
+  <text x="100" y="95" font-size="18" font-family="Arial" text-anchor="middle" fill="#000">$</text>
 </svg>

--- a/img/bonus7.svg
+++ b/img/bonus7.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
   <rect width="200" height="200" fill="#6666ff" />
-  <text x="100" y="105" font-size="36" font-family="Arial" text-anchor="middle" fill="#ffffff">Bonus 3</text>
+  <circle cx="100" cy="100" r="60" fill="#ffffff" />
+  <polygon points="100,40 110,80 150,80 115,100 130,140 100,115 70,140 85,100 50,80 90,80" fill="#ff9900" />
 </svg>

--- a/img/bonus8.svg
+++ b/img/bonus8.svg
@@ -1,4 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
   <rect width="200" height="200" fill="#ffcc66" />
-  <text x="100" y="105" font-size="36" font-family="Arial" text-anchor="middle" fill="#333333">Bonus 4</text>
+  <circle cx="100" cy="100" r="60" fill="#ffffff" />
+  <circle cx="100" cy="100" r="50" fill="#f2a900" />
+  <text x="100" y="115" font-size="50" font-family="Arial" text-anchor="middle" fill="#ffffff">Ƀ</text>
 </svg>


### PR DESCRIPTION
## Summary
- replace placeholder bonus images with simple casino-themed SVG icons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686bda41bf3c8329a46d99370d7a6430