### PR TITLE
Remove hover background from footer quick links

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -496,6 +496,7 @@ body {
 .footer .btn.btn-link:hover {
     color: #C2B280;
     letter-spacing: 1px;
+    background-color: transparent;
     box-shadow: none;
 }
 


### PR DESCRIPTION
## Summary
- prevent background color from appearing when hovering footer quick links

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686e595bc5b08329b6794dbb6c6b08ec