### PR TITLE
Remove footer quick link border on hover

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -497,6 +497,7 @@ body {
     color: #C2B280;
     letter-spacing: 1px;
     background-color: transparent;
+    border-color: transparent;
     box-shadow: none;
 }
 


### PR DESCRIPTION
## Summary
- prevent border from appearing when hovering over footer quicklinks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686e5a6cd8348329805ae7a2758b7000