### PR TITLE
Add affiliate page description and FAQ

### DIFF
--- a/service.html
+++ b/service.html
@@ -161,6 +161,17 @@
     </div>
     <!-- Page Header End -->
 
+    <!-- Affiliate Description Start -->
+    <div class="container-xxl py-5">
+        <div class="container">
+            <div class="col-12 wow fadeInUp" data-wow-delay="0.1s">
+                <h2 class="mb-4">Why Partner With Us?</h2>
+                <p>Our affiliate program connects you with premium casino brands and provides transparent reporting so you can track every click and conversion. Choose from revenue share, CPA or hybrid deals to maximize your earnings.</p>
+                <p>Dedicated managers are on hand to help optimize your campaigns with custom creatives and strategic advice.</p>
+            </div>
+        </div>
+    </div>
+    <!-- Affiliate Description End -->
 
     <!-- Service Start -->
     <div class="container-xxl py-5">
@@ -300,6 +311,86 @@
     </div>
     <!-- SEO End -->
 
+    <!-- FAQ Start -->
+    <div class="container-xxl py-5">
+        <div class="container">
+            <div class="text-center mx-auto mb-5 wow fadeInUp" data-wow-delay="0.1s" style="max-width: 600px;">
+                <h6 class="section-title text-center text-primary px-3">FAQ</h6>
+                <h1 class="display-6 mb-4">Affiliate Program FAQs</h1>
+            </div>
+            <div class="accordion" id="affiliateFaqAccordion">
+                <div class="accordion-item">
+                    <h2 class="accordion-header" id="affiliateFaq1-heading">
+                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#affiliateFaq1" aria-expanded="false" aria-controls="affiliateFaq1">
+                            How do I sign up for the affiliate program?
+                        </button>
+                    </h2>
+                    <div id="affiliateFaq1" class="accordion-collapse collapse" aria-labelledby="affiliateFaq1-heading" data-bs-parent="#affiliateFaqAccordion">
+                        <div class="accordion-body">
+                            Complete the registration form and our team will review your application within 24 hours.
+                        </div>
+                    </div>
+                </div>
+                <div class="accordion-item">
+                    <h2 class="accordion-header" id="affiliateFaq2-heading">
+                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#affiliateFaq2" aria-expanded="false" aria-controls="affiliateFaq2">
+                            When do affiliates get paid?
+                        </button>
+                    </h2>
+                    <div id="affiliateFaq2" class="accordion-collapse collapse" aria-labelledby="affiliateFaq2-heading" data-bs-parent="#affiliateFaqAccordion">
+                        <div class="accordion-body">
+                            Payments are issued monthly once you reach the minimum payout threshold.
+                        </div>
+                    </div>
+                </div>
+                <div class="accordion-item">
+                    <h2 class="accordion-header" id="affiliateFaq3-heading">
+                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#affiliateFaq3" aria-expanded="false" aria-controls="affiliateFaq3">
+                            What marketing materials are provided?
+                        </button>
+                    </h2>
+                    <div id="affiliateFaq3" class="accordion-collapse collapse" aria-labelledby="affiliateFaq3-heading" data-bs-parent="#affiliateFaqAccordion">
+                        <div class="accordion-body">
+                            You'll have access to banners, landing pages and tracking links that are optimized to convert visitors.
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <!-- FAQ End -->
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+            {
+                "@type": "Question",
+                "name": "How do I sign up for the affiliate program?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Complete the registration form and our team will review your application within 24 hours."
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "When do affiliates get paid?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Payments are issued monthly once you reach the minimum payout threshold."
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "What marketing materials are provided?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "You'll have access to banners, landing pages and tracking links that are optimized to convert visitors."
+                }
+            }
+        ]
+    }
+    </script>
 
     <!-- Testimonial Start -->
     <div class="container-xxl py-5">


### PR DESCRIPTION
## Summary
- expand affiliate page with an introductory section describing the program
- add an FAQ section for affiliates including Schema.org markup

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6870fb02307c8329827d9d8216435dd1