### PR TITLE
Update FAQ section styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -705,9 +705,10 @@ body {
 
 #faqAccordion .accordion-button {
     background-color: #333333;
-    color: var(--primary);
+    color: #ffffff;
 }
 
+#faqAccordion .accordion-button:hover,
 #faqAccordion .accordion-button:not(.collapsed) {
     color: var(--primary);
     box-shadow: none;
@@ -715,6 +716,10 @@ body {
 
 #faqAccordion .accordion-button:focus {
     box-shadow: none;
+}
+
+#faqAccordion .accordion-button::after {
+    background-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23ff6600'><path fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/></svg>");
 }
 
 #faqAccordion .accordion-body {


### PR DESCRIPTION
## Summary
- update default FAQ colors to white text on dark grey
- add hover/active state in orange for FAQ buttons
- style the FAQ arrow icon in primary color

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6870fcec83b483299d081046f61d8cdd